### PR TITLE
Allow pyproject.toml to also find submodules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ description = "Analysis code for Hoefling et al. (2024) eLife"
 requires-python = ">=3.8"
 dynamic = ["dependencies"]
 
-[tool.setuptools]
-packages = ["rgc_natstim_model"]
+[tool.setuptools.packages.find]
+include = ["rgc_natstim_model*"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
The previous pyproject.toml file also didn't allow to find submodules like `rgc_natstim_model.constants`, using packages.find allows to find these submodules automatically (at least when the __init__ file is present in each module and submodule. It added it to the main module, too.)

To reproduce this before this PR and check that this is working after this PR you can do the following
```
pip install .
# Changing the directory ensures that it doesn't use the files in the directory, and instead uses the pip installed package
cd ..
python3
```
Then in python do:
```
from rgc_natstim_model.constants.plot_settings import cmap_colors as rgc_colors
# above will work after this PR, but threw the following mistake before:
# ModuleNotFoundError: No module named 'rgc_natstim_model.constants'
```
